### PR TITLE
Add OpenRouter support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # Jutge Problem Solver Environment Variables
 # Copy this file to .env and fill in your actual credentials
 
-# OpenAI API Configuration
-# Get your API key from: https://platform.openai.com/api-keys
-OPENAI_API_KEY=your-openai-api-key-here
+# OpenRouter API Configuration
+# Get your API key from: https://openrouter.ai/
+OPENROUTER_API_KEY=your-openrouter-key-here
 
 # Optional: Override default model
 # OPENAI_MODEL=gpt-4o-mini

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -9,11 +9,9 @@ The benchmark feature allows you to compare the performance of different AI mode
 uv sync --extra benchmark
 ```
 
-2. Set up your API keys:
+2. Set up your API key:
 ```bash
-export OPENAI_API_KEY="your-openai-key"
-export ANTHROPIC_API_KEY="your-anthropic-key"  # Optional
-export GOOGLE_API_KEY="your-google-key"        # Optional
+export OPENROUTER_API_KEY="your-openrouter-key"
 ```
 
 3. Run a benchmark:
@@ -49,7 +47,7 @@ Edit `benchmark_config.yaml` to add new AI models:
 ```yaml
 models:
   - name: "Your-Model-Name"
-    provider: "openai"  # or "anthropic", "google"
+    provider: "openrouter"
     model_id: "model-api-id"
     api_key: null  # Uses environment variable
     max_tokens: 2000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ The project is organized as a comprehensive AI-powered problem solving system:
 - **Testing**: `pytest` with coverage reporting and async support
 
 **Authentication and security:**
-- Environment variables for credentials (`JUTGE_EMAIL`, `JUTGE_PASSWORD`, `OPENAI_API_KEY`)
+- Environment variables for credentials (`JUTGE_EMAIL`, `JUTGE_PASSWORD`, `OPENROUTER_API_KEY`)
 - Interactive credential prompts with `rich.Prompt`
 - Secure credential storage and validation
 - API key management for multiple AI providers

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ vi .env
 
 Add your credentials to `.env`:
 ```bash
-# OpenAI API Configuration
-OPENAI_API_KEY=your-openai-api-key-here
+# OpenRouter API Configuration
+OPENROUTER_API_KEY=your-openrouter-key-here
 
 # Jutge Credentials
 JUTGE_EMAIL=your-email@example.com
@@ -63,9 +63,9 @@ JUTGE_PASSWORD=your-password
 uv run python cli.py config
 ```
 
-### 3. Get Your API Keys
+### 3. Get Your API Key
 
-- **OpenAI API Key**: Get from [OpenAI Platform](https://platform.openai.com/api-keys)
+- **OpenRouter API Key**: Get from [OpenRouter](https://openrouter.ai/)
 - **Jutge Account**: Register at [Jutge.org](https://jutge.org/)
 
 ### 4. Test the Setup
@@ -155,18 +155,19 @@ uv run python cli.py test
 
 ### Credentials (.env file)
 All sensitive credentials are stored in `.env` file:
-- `OPENAI_API_KEY`: Your OpenAI API key
-- `JUTGE_EMAIL`: Your Jutge account email  
+- `OPENROUTER_API_KEY`: Your OpenRouter API key
+- `JUTGE_EMAIL`: Your Jutge account email
 - `JUTGE_PASSWORD`: Your Jutge account password
 - `OPENAI_MODEL`: (Optional) Override default model
 
 ### Non-sensitive Settings (config.yaml)
 Optional configuration file for non-sensitive settings:
 
-**OpenAI Settings**
+**OpenAI/OpenRouter Settings**
 - `model`: GPT model to use (`gpt-4o-mini` for cost-effective, `gpt-4o` for best results)
 - `max_tokens`: Maximum tokens per response
 - `temperature`: Creativity level (0.0-1.0, lower = more deterministic)
+- `base_url`: (Optional) Override API base URL for OpenRouter
 
 **Jutge Settings**
 - `default_compiler`: Default programming language

--- a/benchmark_config.yaml
+++ b/benchmark_config.yaml
@@ -1,36 +1,40 @@
 # Jutge AI Model Benchmark Configuration
 models:
   - name: "GPT-4o-mini"
-    provider: "openai"
-    model_id: "gpt-4o-mini"
-    api_key: null  # Will use OPENAI_API_KEY environment variable
+    provider: "openrouter"
+    model_id: "openai/gpt-4o-mini"
+    api_key: null  # Will use OPENROUTER_API_KEY environment variable
+    base_url: "https://openrouter.ai/api/v1"
     max_tokens: 2000
     temperature: 0.1
     timeout: 30
     enabled: true
 
   - name: "GPT-4o"
-    provider: "openai"
-    model_id: "gpt-4o"
-    api_key: null  # Will use OPENAI_API_KEY environment variable
+    provider: "openrouter"
+    model_id: "openai/gpt-4o"
+    api_key: null  # Will use OPENROUTER_API_KEY environment variable
+    base_url: "https://openrouter.ai/api/v1"
     max_tokens: 2000
     temperature: 0.1
     timeout: 30
     enabled: true
 
   - name: "Claude-3.5-Sonnet"
-    provider: "anthropic"
-    model_id: "claude-3-5-sonnet-20241022"
-    api_key: null  # Will use ANTHROPIC_API_KEY environment variable
+    provider: "openrouter"
+    model_id: "anthropic/claude-3-5-sonnet-20241022"
+    api_key: null  # Will use OPENROUTER_API_KEY environment variable
+    base_url: "https://openrouter.ai/api/v1"
     max_tokens: 2000
     temperature: 0.1
     timeout: 30
     enabled: false  # Disabled by default, enable if API key is available
 
   - name: "Gemini-Pro"
-    provider: "google"
-    model_id: "gemini-pro"
-    api_key: null  # Will use GOOGLE_API_KEY environment variable
+    provider: "openrouter"
+    model_id: "google/gemini-pro"
+    api_key: null  # Will use OPENROUTER_API_KEY environment variable
+    base_url: "https://openrouter.ai/api/v1"
     max_tokens: 2000
     temperature: 0.1
     timeout: 30

--- a/cli.py
+++ b/cli.py
@@ -443,10 +443,10 @@ def setup_interactive_config():
         if not Confirm.ask("Do you want to update it?"):
             return
     
-    # Get OpenAI API key
-    console.print("\\n[bold]OpenAI Configuration[/bold]")
-    console.print("Get your API key from: https://platform.openai.com/api-keys")
-    openai_key = Prompt.ask("Enter your OpenAI API key", password=True)
+    # Get OpenRouter API key
+    console.print("\\n[bold]OpenRouter Configuration[/bold]")
+    console.print("Get your API key from: https://openrouter.ai/")
+    openai_key = Prompt.ask("Enter your OpenRouter API key", password=True)
     
     # Get Jutge credentials
     console.print("\\n[bold]Jutge Credentials[/bold]")
@@ -458,8 +458,8 @@ def setup_interactive_config():
     env_content = f"""# Jutge Problem Solver Environment Variables
 # Generated on {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
 
-# OpenAI API Configuration
-OPENAI_API_KEY={openai_key}
+# OpenRouter API Configuration
+OPENROUTER_API_KEY={openai_key}
 
 # Jutge Platform Credentials
 JUTGE_EMAIL={jutge_email}
@@ -480,9 +480,9 @@ def setup_default_config():
         env_example_content = """# Jutge Problem Solver Environment Variables
 # Copy this file to .env and fill in your actual credentials
 
-# OpenAI API Configuration
-# Get your API key from: https://platform.openai.com/api-keys
-OPENAI_API_KEY=your-openai-api-key-here
+# OpenRouter API Configuration
+# Get your API key from: https://openrouter.ai/
+OPENROUTER_API_KEY=your-openrouter-key-here
 
 # Optional: Override default model
 # OPENAI_MODEL=gpt-4o-mini

--- a/jutge_solver/benchmark.py
+++ b/jutge_solver/benchmark.py
@@ -83,6 +83,8 @@ class AIModelAdapter:
         """Create the appropriate client based on provider"""
         if self.config.provider == "openai":
             return OpenAI(api_key=self.config.api_key)
+        elif self.config.provider == "openrouter":
+            return OpenAI(api_key=self.config.api_key, base_url=self.config.base_url or "https://openrouter.ai/api/v1")
         elif self.config.provider == "anthropic":
             if not HAS_ANTHROPIC:
                 raise ValueError("Anthropic library not installed. Run: pip install anthropic")
@@ -101,7 +103,7 @@ class AIModelAdapter:
         
         start_time = time.time()
         
-        if self.config.provider == "openai":
+        if self.config.provider in {"openai", "openrouter"}:
             response = self.client.chat.completions.create(
                 model=self.config.model_id,
                 messages=[

--- a/jutge_solver/benchmark_config.py
+++ b/jutge_solver/benchmark_config.py
@@ -12,13 +12,14 @@ from datetime import datetime
 class AIModelConfig(BaseModel):
     """Configuration for a single AI model"""
     name: str
-    provider: str  # "openai", "anthropic", "google", etc.
+    provider: str  # "openai", "anthropic", "google", "openrouter", etc.
     model_id: str
     api_key: Optional[str] = None
     max_tokens: int = 2000
     temperature: float = 0.1
     timeout: int = 30
     enabled: bool = True
+    base_url: Optional[str] = None
 
 
 class BenchmarkConfig(BaseModel):
@@ -39,26 +40,29 @@ class BenchmarkConfig(BaseModel):
         default_models = [
             AIModelConfig(
                 name="GPT-4o-mini",
-                provider="openai",
-                model_id="gpt-4o-mini",
-                api_key=os.getenv("OPENAI_API_KEY"),
-                temperature=0.1
+                provider="openrouter",
+                model_id="openai/gpt-4o-mini",
+                api_key=os.getenv("OPENROUTER_API_KEY"),
+                temperature=0.1,
+                base_url="https://openrouter.ai/api/v1",
             ),
             AIModelConfig(
                 name="GPT-4o",
-                provider="openai", 
-                model_id="gpt-4o",
-                api_key=os.getenv("OPENAI_API_KEY"),
-                temperature=0.1
+                provider="openrouter",
+                model_id="openai/gpt-4o",
+                api_key=os.getenv("OPENROUTER_API_KEY"),
+                temperature=0.1,
+                base_url="https://openrouter.ai/api/v1",
             ),
             # Placeholder for other models - can be extended
             AIModelConfig(
                 name="Claude-3.5-Sonnet",
-                provider="anthropic",
-                model_id="claude-3-5-sonnet-20241022",
-                api_key=os.getenv("ANTHROPIC_API_KEY"),
+                provider="openrouter",
+                model_id="anthropic/claude-3-5-sonnet-20241022",
+                api_key=os.getenv("OPENROUTER_API_KEY"),
                 temperature=0.1,
-                enabled=False  # Disabled by default until API key is provided
+                enabled=False,
+                base_url="https://openrouter.ai/api/v1",
             ),
         ]
         
@@ -100,6 +104,10 @@ class BenchmarkConfig(BaseModel):
                         model.api_key = os.getenv("ANTHROPIC_API_KEY")
                     elif model.provider == "google":
                         model.api_key = os.getenv("GOOGLE_API_KEY")
+                    elif model.provider == "openrouter":
+                        model.api_key = os.getenv("OPENROUTER_API_KEY")
+                        if model.base_url is None:
+                            model.base_url = "https://openrouter.ai/api/v1"
             
             return config
         except FileNotFoundError:

--- a/jutge_solver/config.py
+++ b/jutge_solver/config.py
@@ -18,6 +18,7 @@ class OpenAIConfig(BaseModel):
     max_tokens: int = 2000
     temperature: float = 0.1
     timeout: int = 30
+    base_url: Optional[str] = None
 
 
 class JutgeConfig(BaseModel):
@@ -51,6 +52,9 @@ class Config(BaseModel):
         # Load from environment variables
         if api_key := os.getenv("OPENAI_API_KEY"):
             config.openai.api_key = api_key
+        elif api_key := os.getenv("OPENROUTER_API_KEY"):
+            config.openai.api_key = api_key
+            config.openai.base_url = "https://openrouter.ai/api/v1"
         if model := os.getenv("OPENAI_MODEL"):
             config.openai.model = model
         if email := os.getenv("JUTGE_EMAIL"):

--- a/jutge_solver/solver.py
+++ b/jutge_solver/solver.py
@@ -39,7 +39,10 @@ class JutgeProblemSolver:
         
         # Initialize components
         self.jutge_client = JutgeApiClient()
-        self.openai_client = openai.OpenAI(api_key=self.config.openai.api_key)
+        self.openai_client = openai.OpenAI(
+            api_key=self.config.openai.api_key,
+            base_url=self.config.openai.base_url,
+        )
         self.problem_analyzer = ProblemAnalyzer(self.jutge_client)
         self.solution_generator = SolutionGenerator(self.openai_client, self.config.openai)
         self.verdict_manager = VerdictManager(self.jutge_client, self.config.jutge)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -62,8 +62,8 @@ def test_openai_setup():
     config.load_env_file()
     
     if not config.openai.api_key:
-        print("❌ OpenAI API key not found in environment")
-        print("   Please add OPENAI_API_KEY to your .env file")
+        print("❌ OpenRouter API key not found in environment")
+        print("   Please add OPENROUTER_API_KEY to your .env file")
         return False
     
     try:


### PR DESCRIPTION
## Summary
- integrate OpenRouter provider in benchmark and config
- update default benchmark configuration to use OpenRouter
- document new OPENROUTER_API_KEY variable
- tweak CLI and tests for OpenRouter

## Testing
- `uv run ruff format .` *(fails: tunnel error)*
- `uv run pytest -q` *(fails: tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68823645d120832eaed841194cd8fe69